### PR TITLE
Add --debug to open a query in ActiveData's query tool #17

### DIFF
--- a/adr/cli.py
+++ b/adr/cli.py
@@ -3,6 +3,8 @@ from __future__ import print_function, absolute_import
 import logging
 import os
 import sys
+import webbrowser
+import time
 
 from argparse import ArgumentParser
 
@@ -43,7 +45,11 @@ def query_handler(args, remainder):
         if query not in queries:
             log.error("query '{}' not found!".format(query))
             continue
-        print(format_query(query, args, fmt=args.fmt))
+        data, url = format_query(query, args, fmt=args.fmt)
+        print(data)
+        if url:
+            time.sleep(2)
+            webbrowser.open(url, new=2)
 
 
 def recipe_handler(args, remainder):
@@ -90,6 +96,8 @@ def _build_parser_arguments(parser):
                         help="Print the query and other debugging information.")
     parser.add_argument('-u', '--url', default='http://activedata.allizom.org/query',
                         help="Endpoint URL")
+    parser.add_argument('-d', '--debug', action='store_true', default=False,
+                        help="Open a query in ActiveData query tool.")
     # positional arguments
     parser.add_argument('task', nargs='*')
     return parser

--- a/adr/query.py
+++ b/adr/query.py
@@ -9,10 +9,9 @@ import requests
 import yaml
 from six import string_types
 from adr.formatter import all_formatters
-import sys
-if sys.version_info >= (3, 0):
+try:
     from urllib.parse import urlparse
-elif sys.version_info < (3, 0) and sys.version_info >= (2, 5):
+except ImportError:
     from urlparse import urlparse
 
 log = logging.getLogger('adr')

--- a/adr/query.py
+++ b/adr/query.py
@@ -8,13 +8,18 @@ import jsone
 import requests
 import yaml
 from six import string_types
-
 from adr.formatter import all_formatters
+import sys
+if sys.version_info >= (3, 0):
+    from urllib.parse import urlparse
+elif sys.version_info < (3, 0) and sys.version_info >= (2, 5):
+    from urlparse import urlparse
 
 log = logging.getLogger('adr')
 here = os.path.abspath(os.path.dirname(__file__))
 
 ACTIVE_DATA_URL = "http://activedata.allizom.org/query"
+DEBUG_URL = "{}://{}/tools/query.html#query_id={}"
 QUERY_DIR = os.path.join(here, 'queries')
 FAKE_CONTEXT = {
     'branch': 'mozilla-central',
@@ -69,7 +74,7 @@ def load_query(name):
             yield query
 
 
-def run_query(name, **context):
+def run_query(name, debug=False, **context):
     """Loads and runs the specified query, yielding the result.
 
     Given name of a query, this method will first read the query
@@ -82,6 +87,7 @@ def run_query(name, **context):
     inside the query_activedata method.
 
     :param str name: name of the query file to be loaded.
+    :param debug: enable debug mode.
     :param dict context: dictionary of ActiveData configs.
     :yields str: json-formatted string.
     """
@@ -92,6 +98,8 @@ def run_query(name, **context):
             query['limit'] = context['limit']
         if 'format' in context:
             query['format'] = context['format']
+        if debug:
+            query['meta'] = {"save": True}
 
         query = jsone.render(query, context)
         query_str = json.dumps(query, indent=2, separators=(',', ':'))
@@ -112,8 +120,13 @@ def format_query(query, args, fmt='table'):
     if isinstance(fmt, string_types):
         fmt = all_formatters[fmt]
 
-    for result in run_query(query, **FAKE_CONTEXT):
+    for result in run_query(query, args.debug, **FAKE_CONTEXT):
         data = result['data']
+        url = None
+        if 'saved_as' in result['meta']:
+            query_id = result['meta']['saved_as']
+            domain = urlparse(ACTIVE_DATA_URL)
+            url = DEBUG_URL.format(domain.scheme, domain.netloc, query_id)
 
         if args.fmt == 'json':
             return fmt(result)
@@ -126,4 +139,4 @@ def format_query(query, args, fmt='table'):
         if 'header' in result:
             data.insert(0, result['header'])
 
-        return fmt(data)
+        return fmt(data), url


### PR DESCRIPTION
Thank @klahnakoski for detailed information. I followed it and made a modification. And I have some concerns: 1) When I tried to run the query, the command is "adr query" instead of "adr-query"; 2) I used `FAKE_CONTEXT["debug"] = args.debug`; but not sure it is a good solution or not 3) When opening a browser, I tried to use args.url, it stores "http://activedata.allizom.org/query" (which is the same with the url in the guide) but it didn't work, so I tried "http://activedata.allizom.org/tools/query.html" instead. Thank you.