### PR TITLE
Fixed JSON output formatting.

### DIFF
--- a/adr/query.py
+++ b/adr/query.py
@@ -128,7 +128,7 @@ def format_query(query, args, fmt='table'):
             url = DEBUG_URL.format(domain.scheme, domain.netloc, query_id)
 
         if args.fmt == 'json':
-            return fmt(result)
+            return fmt(result), url
 
         if 'edges' in result:
             for edge in result['edges']:


### PR DESCRIPTION
The format_query function expected to return a tuple but it looked like it was missed. Added URL to the expected return. --format json now works on the command line for ADR.