### PR TITLE
Added a unittest for query.py

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,6 +15,7 @@ def load_recipe_tests():
             for test in yaml.load_all(fh):
                 yield test
 
+
 def load_query_tests():
     query_dir = os.path.join(here, 'query_tests')
     queries = [os.path.join(query_dir, q) for q in os.listdir(query_dir) if q.endswith('.test')]
@@ -23,11 +24,14 @@ def load_query_tests():
             for test in yaml.load_all(fh):
                 yield test
 
+
 def recipe_idfn(val):
     return '{} {}'.format(val['recipe'], ' '.join(val['args'])).strip()
 
+
 def query_idfn(val):
     return '{} {}'.format(val['query'], ' '.join(val['args'])).strip()
+
 
 def pytest_generate_tests(metafunc):
     if 'recipe_test' in metafunc.fixturenames:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,11 +15,22 @@ def load_recipe_tests():
             for test in yaml.load_all(fh):
                 yield test
 
+def load_query_tests():
+    query_dir = os.path.join(here, 'query_tests')
+    queries = [os.path.join(query_dir, q) for q in os.listdir(query_dir) if q.endswith('.test')]
+    for query in queries:
+        with open(query, 'r') as fh:
+            for test in yaml.load_all(fh):
+                yield test
 
-def idfn(val):
+def recipe_idfn(val):
     return '{} {}'.format(val['recipe'], ' '.join(val['args'])).strip()
 
+def query_idfn(val):
+    return '{} {}'.format(val['query'], ' '.join(val['args'])).strip()
 
 def pytest_generate_tests(metafunc):
     if 'recipe_test' in metafunc.fixturenames:
-        metafunc.parametrize('recipe_test', list(load_recipe_tests()), ids=idfn)
+        metafunc.parametrize('recipe_test', list(load_recipe_tests()), ids=recipe_idfn)
+    if 'query_test' in metafunc.fixturenames:
+        metafunc.parametrize('query_test', list(load_query_tests()), ids=query_idfn)

--- a/test/query_tests/total_files.test
+++ b/test/query_tests/total_files.test
@@ -1,0 +1,83 @@
+query: total_files
+from: firefox-files
+groupby:
+    - repo.changeset.id12
+    - repo.changeset.date
+sort:
+    repo.changeset.date: desc
+limit: 50
+expected:
+  header:
+    - repo.changeset.id12
+    - repo.changeset.date
+    - count
+  meta:
+    timing:
+      save: 2.098e-05
+      translate: 0.4155
+      es_search: 0.3822169303894043
+      jsonification: 0.000495
+      formatting: 0.0013539791107177734
+      total: 0.418
+      preamble: 0.000699
+    es_query:
+      aggs:
+        _match:
+          terms:
+            field: repo.changeset.date
+            order:
+              _term: desc
+            size: 10
+          aggs:
+            _match:
+              terms:
+                field: repo.changeset.id12
+                size: 10
+            _missing:
+              missing:
+                field: repo.changeset.id12
+        _missing:
+          aggs:
+            _match:
+              terms:
+                field: repo.changeset.id12
+                size: 10
+            _missing:
+              missing:
+                field: repo.changeset.id12
+          missing:
+            field: repo.changeset.date
+      size: 0
+    content_type: application/json
+    format: table
+  data:
+  - - 20773596530b
+    - 1539192708
+    - 251364
+  - - 1a9cbc785296
+    - 1539189000
+    - 251364
+  - - 0f1d5395f801
+    - 1539187620
+    - 251336
+  - - 8dfeff72def3
+    - 1539186779
+    - 251334
+  - - 91b4c3687d75
+    - 1539168720
+    - 251337
+  - - 2d2dee08739f
+    - 1539154819
+    - 251334
+  - - f5681e1f56e6
+    - 1539152160
+    - 251334
+  - - bf31de5be0dc
+    - 1539146100
+    - 251337
+  - - 6f8701d1be0c
+    - 1539122340
+    - 251327
+  - - 4845f02cf354
+    - 1539122280
+    - 251320

--- a/test/query_tests/total_files.test
+++ b/test/query_tests/total_files.test
@@ -1,11 +1,81 @@
 query: total_files
-from: firefox-files
-groupby:
+
+mock_data:
+  header:
     - repo.changeset.id12
     - repo.changeset.date
-sort:
-    repo.changeset.date: desc
-limit: 50
+    - count
+  meta:
+    timing:
+      save: 2.098e-05
+      translate: 0.4155
+      es_search: 0.3822169303894043
+      jsonification: 0.000495
+      formatting: 0.0013539791107177734
+      total: 0.418
+      preamble: 0.000699
+    es_query:
+      aggs:
+        _match:
+          terms:
+            field: repo.changeset.date
+            order:
+              _term: desc
+            size: 10
+          aggs:
+            _match:
+              terms:
+                field: repo.changeset.id12
+                size: 10
+            _missing:
+              missing:
+                field: repo.changeset.id12
+        _missing:
+          aggs:
+            _match:
+              terms:
+                field: repo.changeset.id12
+                size: 10
+            _missing:
+              missing:
+                field: repo.changeset.id12
+          missing:
+            field: repo.changeset.date
+      size: 0
+    content_type: application/json
+    format: table
+  data:
+  - - 20773596530b
+    - 1539192708
+    - 251364
+  - - 1a9cbc785296
+    - 1539189000
+    - 251364
+  - - 0f1d5395f801
+    - 1539187620
+    - 251336
+  - - 8dfeff72def3
+    - 1539186779
+    - 251334
+  - - 91b4c3687d75
+    - 1539168720
+    - 251337
+  - - 2d2dee08739f
+    - 1539154819
+    - 251334
+  - - f5681e1f56e6
+    - 1539152160
+    - 251334
+  - - bf31de5be0dc
+    - 1539146100
+    - 251337
+  - - 6f8701d1be0c
+    - 1539122340
+    - 251327
+  - - 4845f02cf354
+    - 1539122280
+    - 251320
+
 expected:
   header:
     - repo.changeset.id12

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -54,4 +54,3 @@ def test_query(monkeypatch, query_test, config):
     print("\nYaml formatted expected:")
     print(buf.getvalue())
     assert result == query_test["expected"]
-    

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -8,10 +8,9 @@ from io import BytesIO, StringIO
 import pytest
 import yaml
 
-from argparse import Namespace
-
 from adr import formatter
 from adr.query import format_query, run_query, query_activedata
+from adr.util.config import Configuration
 
 if sys.version_info > (3, 0):
     IO = StringIO
@@ -19,22 +18,23 @@ else:
     IO = BytesIO
 
 @pytest.fixture
-def args():
-	args = Namespace()
-	args.debug = 'debug'
-	args.fmt = 'fmt'
-	return args
+def config():
+    congif = Configuration()
+    config.debug = False
+    config.fmt = 'json'
+    config.url = "http://activedata.allizom.org/query"
+    return config
 
-def test_query(query_test, args):
-
+def test_query(query_test, config):
     module = 'adr.queries.{}'.format(query_test['query'])
     if module in sys.modules:
         reload(sys.modules[module])
 
-    result = json.loads(format_query(query_test['query'], args.debug, fmt='json'))
-    #Line 35 - having trouble converting format as JSON expects a string or buffer
-    #and args is a namespace object. Currently when running test in the terminal,
-    #AttributeError: 'str' object has no attribute 'debug' 
+    result = json.loads(format_query(query_test['query'], config))
+    #Line 35 - having trouble converting format as when in terminal the 
+    #following error appears:
+    #TypeError: expected string or buffer
+    #It could be because config is an object? Not sure how to resolve...
     
     buf = IO()
     yaml.dump(result, buf)

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -8,15 +8,15 @@ from io import BytesIO, StringIO
 import pytest
 import yaml
 
-from adr import formatter
 from adr import query
-from adr.query import format_query, query_activedata
+from adr.query import format_query
 from adr.util.config import Configuration
 
 if sys.version_info > (3, 0):
     IO = StringIO
 else:
     IO = BytesIO
+
 
 @pytest.fixture
 def config():
@@ -26,12 +26,14 @@ def config():
     config.url = "http://activedata.allizom.org/query"
     return config
 
+
 class RunQuery(object):
     def __init__(self, query_test):
         self.query_test = query_test
 
     def __call__(self, query, *args, **kwargs):
         return self.query_test['mock_data']
+
 
 def test_query(monkeypatch, query_test, config):
 
@@ -41,7 +43,7 @@ def test_query(monkeypatch, query_test, config):
         reload(sys.modules[module])
 
     result = json.loads(format_query(query_test['query'], config)[0])
-   
+
     buf = IO()
     yaml.dump(result, buf)
     print("Yaml formatted result for copy/paste:")
@@ -52,4 +54,4 @@ def test_query(monkeypatch, query_test, config):
     print("\nYaml formatted expected:")
     print(buf.getvalue())
     assert result == query_test["expected"]
-
+    

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -31,7 +31,7 @@ def test_query(query_test, config):
         reload(sys.modules[module])
 
     result = json.loads(format_query(query_test['query'], config))
-    #Line 35 - having trouble converting format as when in terminal the 
+    #Line 33 - having trouble converting format to json as in terminal the 
     #following error appears:
     #TypeError: expected string or buffer
     #It could be because config is an object? Not sure how to resolve...

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, absolute_import
+from __future__ import print_function, absolute_import, unicode_literals
 
 import json
 import sys
@@ -9,7 +9,8 @@ import pytest
 import yaml
 
 from adr import formatter
-from adr.query import format_query, run_query, query_activedata
+from adr import query
+from adr.query import format_query, query_activedata
 from adr.util.config import Configuration
 
 if sys.version_info > (3, 0):
@@ -19,23 +20,28 @@ else:
 
 @pytest.fixture
 def config():
-    congif = Configuration()
+    config = Configuration()
     config.debug = False
     config.fmt = 'json'
     config.url = "http://activedata.allizom.org/query"
     return config
 
-def test_query(query_test, config):
+class RunQuery(object):
+    def __init__(self, query_test):
+        self.query_test = query_test
+
+    def __call__(self, query, *args, **kwargs):
+        return self.query_test['mock_data']
+
+def test_query(monkeypatch, query_test, config):
+
+    monkeypatch.setattr(query, 'query_activedata', RunQuery(query_test))
     module = 'adr.queries.{}'.format(query_test['query'])
     if module in sys.modules:
         reload(sys.modules[module])
 
-    result = json.loads(format_query(query_test['query'], config))
-    #Line 33 - having trouble converting format to json as in terminal the 
-    #following error appears:
-    #TypeError: expected string or buffer
-    #It could be because config is an object? Not sure how to resolve...
-    
+    result = json.loads(format_query(query_test['query'], config)[0])
+   
     buf = IO()
     yaml.dump(result, buf)
     print("Yaml formatted result for copy/paste:")
@@ -45,4 +51,5 @@ def test_query(query_test, config):
     yaml.dump(query_test['expected'], buf)
     print("\nYaml formatted expected:")
     print(buf.getvalue())
-    assert result == query_test['expected']
+    assert result == query_test["expected"]
+

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -1,0 +1,48 @@
+from __future__ import print_function, absolute_import
+
+import json
+import sys
+from imp import reload
+from io import BytesIO, StringIO
+
+import pytest
+import yaml
+
+from argparse import Namespace
+
+from adr import formatter
+from adr.query import format_query, run_query, query_activedata
+
+if sys.version_info > (3, 0):
+    IO = StringIO
+else:
+    IO = BytesIO
+
+@pytest.fixture
+def args():
+	args = Namespace()
+	args.debug = 'debug'
+	args.fmt = 'fmt'
+	return args
+
+def test_query(query_test, args):
+
+    module = 'adr.queries.{}'.format(query_test['query'])
+    if module in sys.modules:
+        reload(sys.modules[module])
+
+    result = json.loads(format_query(query_test['query'], args.debug, fmt='json'))
+    #Line 35 - having trouble converting format as JSON expects a string or buffer
+    #and args is a namespace object. Currently when running test in the terminal,
+    #AttributeError: 'str' object has no attribute 'debug' 
+    
+    buf = IO()
+    yaml.dump(result, buf)
+    print("Yaml formatted result for copy/paste:")
+    print(buf.getvalue())
+
+    buf = IO()
+    yaml.dump(query_test['expected'], buf)
+    print("\nYaml formatted expected:")
+    print(buf.getvalue())
+    assert result == query_test['expected']


### PR DESCRIPTION
#28  @ahal  My additions so far.

- Added test_queries.py, following a similar structure to the recipe tests.
- Edited conftest.py to also include ability to read .test files from the newly created query_tests folder.
- For now I have only been testing against the data total_files query returns, as that query is known to work. 

I haven't been able to successfully run the test yet as I struck an error. If someone could please take a look at my notes in the test_queries.py file, I would love some feedback. Am I on the right track?

Thank you!
