### PR TITLE
Fix bug in branch selection

### DIFF
--- a/adr/recipes/task_durations.py
+++ b/adr/recipes/task_durations.py
@@ -22,7 +22,7 @@ DEFAULT_BRANCHES = [
 
 def run(args, config):
     parser = RecipeParser('build', 'date', 'platform')
-    parser.add_argument('-B', '--branch', default=DEFAULT_BRANCHES, action='append',
+    parser.add_argument('-B', '--branch', default=DEFAULT_BRANCHES, nargs='+',
                         help="Branches to gather backout rate on, can be specified "
                              "multiple times.")
     parser.add_argument('--limit', type=int, default=20,
@@ -32,6 +32,7 @@ def run(args, config):
 
     args = parser.parse_args(args)
     query_args = vars(args)
+    print(query_args)
     limit = query_args.pop('limit')
 
     data = next(run_query('task_durations', config, **query_args))['data']

--- a/adr/recipes/task_durations.py
+++ b/adr/recipes/task_durations.py
@@ -32,7 +32,6 @@ def run(args, config):
 
     args = parser.parse_args(args)
     query_args = vars(args)
-    
     limit = query_args.pop('limit')
 
     data = next(run_query('task_durations', config, **query_args))['data']

--- a/adr/recipes/task_durations.py
+++ b/adr/recipes/task_durations.py
@@ -32,7 +32,7 @@ def run(args, config):
 
     args = parser.parse_args(args)
     query_args = vars(args)
-    print(query_args)
+    
     limit = query_args.pop('limit')
 
     data = next(run_query('task_durations', config, **query_args))['data']


### PR DESCRIPTION
When a user runs adr task_durations --branch mozilla-inbound the 'branch' value is still the default set instead of just ['mozilla-inbound']. This pull request provides a fix to bug by selecting the specified branch and displaying its data.