### PR TITLE
fixed an opening tag's name in layout.html

### DIFF
--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <title>Active Data Query</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css">
-  </head>
-  <body>
-    {% block body%}{% endblock %}
-    <stript src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"></script>
-  </body>
+    <head>
+        <meta charset="utf-8">
+            <title>Active Data Query</title>
+            <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css">
+                </head>
+    <body>
+        {% block body%}{% endblock %}
+        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"></script>
+    </body>
 </html>


### PR DESCRIPTION
There was an error with  `<stript` in place of `<script` on line 10 in app/templates/layout.html.