### PR TITLE
Setting software requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ output can sometimes be post-processed.
 
 Each recipe should try to answer a single question.
 
+# Software requirements
+
+- You will need python 3.6 and pip for python 3.6 installed on your machine to run the program.
+
+
 # Installation
 
     pip install active-data-recipes


### PR DESCRIPTION
Since after commit df5a3d, the project no longer supports python 2.7, but supports only python 3.6, it is important to set up software requirements in README.md.