### PR TITLE
Pin pytest version in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,13 @@ envlist=py36,flake8,doclint
 
 [testenv]
 deps=
-    pytest
+    pytest >= 3.0.0, <4
 passenv=TRAVIS_EVENT_TYPE
 commands=pytest -vv -rfx --tb=short
 
 [testenv:integ]
 deps=
-    pytest
+    pytest >= 3.0.0, <4
 setenv=
     TRAVIS_EVENT_TYPE=cron
 commands=pytest -vv -rfx --tb=short test/test_recipes_integration.py


### PR DESCRIPTION
Pinned a Pytest version range in tox to account for any upgrades up until, but not including, version 4. That way we can choose when to switch to 4 and, in the meantime, not be affected by discrepancies that may occur with said upgrade.