### PR TITLE
Display query_test name and args

### DIFF
--- a/test/query_tests/activedata_usage.test
+++ b/test/query_tests/activedata_usage.test
@@ -1,6 +1,6 @@
 query: activedata_usage
 
-debug: False
+args: []
 
 mock_data:
   header:
@@ -56,7 +56,7 @@ expected:
 
 query: activedata_usage
 
-debug: True
+args: [--debug]
 
 mock_data:
   header:

--- a/test/query_tests/backout_rate.test
+++ b/test/query_tests/backout_rate.test
@@ -1,6 +1,6 @@
 query: backout_rate
 
-debug: False
+args: []
 
 mock_data:
   header:
@@ -24,7 +24,7 @@ expected:
 
 query: backout_rate
 
-debug: True
+args: [--debug]
 
 mock_data:
   header:

--- a/test/query_tests/code_coverage_by_suite.test
+++ b/test/query_tests/code_coverage_by_suite.test
@@ -1,6 +1,6 @@
 query: code_coverage_by_suite
 
-debug: False
+args: []
 
 mock_data:
   header:
@@ -32,7 +32,7 @@ expected:
 
 query: code_coverage_by_suite
 
-debug: True
+args: [--debug]
 
 mock_data:
   header:

--- a/test/query_tests/config_durations.test
+++ b/test/query_tests/config_durations.test
@@ -1,6 +1,6 @@
 query: config_durations
 
-debug: False
+args: []
 
 mock_data:
   header:
@@ -84,7 +84,7 @@ expected:
 
 query: config_durations
 
-debug: True
+args: [--debug]
 
 mock_data:
   header:

--- a/test/query_tests/covered_files.test
+++ b/test/query_tests/covered_files.test
@@ -1,6 +1,6 @@
 query: covered_files
 
-debug: False
+args: []
 
 mock_data:
   header:
@@ -108,7 +108,7 @@ expected:
 
 query: covered_files
 
-debug: True
+args: [--debug]
 
 mock_data:
   header:

--- a/test/query_tests/fixed_by_commit_jobs.test
+++ b/test/query_tests/fixed_by_commit_jobs.test
@@ -1,6 +1,6 @@
 query: fixed_by_commit_jobs
 
-debug: False
+args: []
 
 mock_data:
   header:
@@ -60,7 +60,7 @@ expected:
 
 query: fixed_by_commit_jobs
 
-debug: True
+args: [--debug]
 
 mock_data:
   header:

--- a/test/query_tests/meta.test
+++ b/test/query_tests/meta.test
@@ -1,6 +1,6 @@
 query: meta
 
-debug: False
+args: []
 
 mock_data:
   header:
@@ -58,7 +58,7 @@ expected:
 
 query: meta
 
-debug: True
+args: [--debug]
 
 mock_data:
   header:

--- a/test/query_tests/raw_coverage_count.test
+++ b/test/query_tests/raw_coverage_count.test
@@ -1,6 +1,6 @@
 query: raw_coverage_count
 
-debug: False
+args: []
 
 mock_data:
   header:
@@ -24,7 +24,7 @@ expected:
 
 query: raw_coverage_count
 
-debug: True
+args: [--debug]
 
 mock_data:
   header:

--- a/test/query_tests/total_files.test
+++ b/test/query_tests/total_files.test
@@ -1,6 +1,6 @@
 query: total_files
 
-debug: False
+args: []
 
 mock_data:
   header:
@@ -86,7 +86,7 @@ expected:
 
 query: total_files
 
-debug: True
+args: [--debug]
 
 mock_data:
   header:

--- a/test/query_tests/total_hours_spent_on_branch.test
+++ b/test/query_tests/total_hours_spent_on_branch.test
@@ -1,6 +1,6 @@
 query: total_hours_spent_on_branch
 
-debug: False
+args: []
 
 mock_data:
   header:
@@ -28,7 +28,7 @@ expected:
 
 query: total_hours_spent_on_branch
 
-debug: True
+args: [--debug]
 
 mock_data:
   header:

--- a/test/query_tests/try_commit_messages.test
+++ b/test/query_tests/try_commit_messages.test
@@ -1,6 +1,6 @@
 query: try_commit_messages
 
-debug: False
+args: []
 
 mock_data:
   header:
@@ -28,7 +28,7 @@ expected:
 
 query: try_commit_messages
 
-debug: True
+args: [--debug]
 
 mock_data:
   header:

--- a/test/query_tests/user_pushes.test
+++ b/test/query_tests/user_pushes.test
@@ -1,6 +1,6 @@
 query: user_pushes
 
-debug: False
+args: []
 
 mock_data:
   header:
@@ -28,7 +28,7 @@ expected:
 
 query: user_pushes
 
-debug: True
+args: [--debug]
 
 mock_data:
   header:

--- a/test/query_tests/user_tasks.test
+++ b/test/query_tests/user_tasks.test
@@ -1,6 +1,6 @@
 query: user_tasks
 
-debug: False
+args: []
 
 mock_data:
   header:
@@ -32,7 +32,7 @@ expected:
 
 query: user_tasks
 
-debug: True
+args: [--debug]
 
 mock_data:
   header:

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -53,7 +53,7 @@ def test_query(monkeypatch, query_test, config):
         print("\nYaml formatted expected:")
         print(buf.getvalue())
 
-    if query_test['debug']:
+    if query_test['args']:
 
         config.debug = True
         formatted_query = format_query(query_test['query'], config)


### PR DESCRIPTION
Fixed warning from pytest. Added "args" to .test files, as IDS created by query_idfn() in conftest.py expected this value. Plus this also displays the names of each file with whether or not --debug is True and tested. In future, this might be used to switch between "table" and "json" testing.