### PR TITLE
Tracking time message in verbose

### DIFF
--- a/adr/query.py
+++ b/adr/query.py
@@ -41,12 +41,12 @@ def query_activedata(query, url):
     :param str url: url to run query
     :returns str: json-formatted string.
     """
-    start_time = time.clock()
+    start_time = time.time()
     response = requests.post(url,
                              data=query,
                              stream=True)
     log.debug("Query execution time: "
-              + "{:.3f} ms".format((time.clock() - start_time) * 1000.0))
+              + "{:.3f} ms".format((time.time() - start_time) * 1000.0))
 
     if response.status_code != 200:
         try:

--- a/adr/query.py
+++ b/adr/query.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, absolute_import
 
 import datetime
+import time
 import json
 import logging
 import os
@@ -40,9 +41,12 @@ def query_activedata(query, url):
     :param str url: url to run query
     :returns str: json-formatted string.
     """
+    start_time = time.clock()
     response = requests.post(url,
                              data=query,
                              stream=True)
+    log.debug("Query execution time: "
+              + "{:.3f} ms".format((time.clock() - start_time) * 1000.0))
 
     if response.status_code != 200:
         try:
@@ -71,7 +75,7 @@ def load_query(name):
     :param str name: name of the query to be run.
     :yields dict query: dictionary representation of yaml query.
     """
-    with open(os.path.join(QUERY_DIR, name+'.query')) as fh:
+    with open(os.path.join(QUERY_DIR, name + '.query')) as fh:
         for query in yaml.load_all(fh):
             yield query
 

--- a/adr/recipes/code_coverage.py
+++ b/adr/recipes/code_coverage.py
@@ -21,5 +21,5 @@ def run(args, config):
     query_args = vars(args)
 
     result = next(run_query('code_coverage', config, **query_args))
-    output = [result['header']]+result['data']
+    output = [result['header']] + result['data']
     return output

--- a/adr/recipes/config_durations.py
+++ b/adr/recipes/config_durations.py
@@ -31,7 +31,7 @@ def run(args, config):
             continue
         if record[3] is None:
             continue
-        record[3] = round(record[3]/60, 2)
+        record[3] = round(record[3] / 60, 2)
         record.append(int(round(record[2] * record[3], 0)))
         result.append(record)
 

--- a/adr/recipes/seta_accuracy.py
+++ b/adr/recipes/seta_accuracy.py
@@ -103,7 +103,7 @@ def run(args, config):
 
     start = date(int(from_date[0]), int(from_date[1]), int(from_date[2]))
     end = date(int(to_date[0]), int(to_date[1]), int(to_date[2]))
-    day = start + timedelta(days=(6-start.weekday()))
+    day = start + timedelta(days=(6 - start.weekday()))
     day -= timedelta(days=7)
     results = []
     while day < end:

--- a/adr/recipes/task_durations.py
+++ b/adr/recipes/task_durations.py
@@ -39,7 +39,7 @@ def run(args, config):
     for record in data:
         if record[2] is None:
             continue
-        record[2] = round(record[2]/60, 2)
+        record[2] = round(record[2] / 60, 2)
         record.append(int(round(record[1] * record[2], 0)))
         result.append(record)
 

--- a/adr/recipes/try_efficiency.py
+++ b/adr/recipes/try_efficiency.py
@@ -31,7 +31,7 @@ def run(args, config):
     data = next(run_query('total_hours_spent_on_branch', config, **query_args))['data']
 
     try_hours = int(data['hours'])
-    try_efficiency = round(10000000/(backout_rate * try_hours), 2)
+    try_efficiency = round(10000000 / (backout_rate * try_hours), 2)
 
     return (
         ['Backout Rate', 'Total Compute Hours on Try', 'Try Efficiency'],

--- a/adr/recipes/try_usage.py
+++ b/adr/recipes/try_usage.py
@@ -66,7 +66,7 @@ def run(args, config):
 
     def fmt(key):
         percent = round(float(count[key]) / count['total'] * 100, 1)
-        return [d[key]['method'], count[key], percent, len(users[key]), round(float(count[key])/len(users[key]), 2)]  # noqa
+        return [d[key]['method'], count[key], percent, len(users[key]), round(float(count[key]) / len(users[key]), 2)]  # noqa
 
     data = [['Method', 'Pushes', 'Percent', 'Users', 'Push / User']]
     for k, v in sorted(count.items(), key=lambda t: t[1], reverse=True):

--- a/adr/recipes/try_users.py
+++ b/adr/recipes/try_users.py
@@ -24,7 +24,7 @@ def run(args, config):
     args = parser.parse_args(args)
 
     header = ['User', 'Tasks', 'Pushes', 'Tasks / Push']
-    if args.sort_key < 0 or len(header)-1 < args.sort_key:
+    if args.sort_key < 0 or len(header) - 1 < args.sort_key:
         parser.error("invalid value for 'sort_key'")
 
     query_args = vars(args)
@@ -47,7 +47,7 @@ def run(args, config):
         if len(value) != 2:
             continue
         tasks, pushes = value
-        data.append([user, tasks, pushes, round(float(tasks)/pushes, 2)])
+        data.append([user, tasks, pushes, round(float(tasks) / pushes, 2)])
 
     data = sorted(data, key=lambda k: k[args.sort_key], reverse=True)
     data = data[:limit]

--- a/adr/util/hgmo.py
+++ b/adr/util/hgmo.py
@@ -16,7 +16,7 @@ def get_directory_list(url=MOZILLA_CENTRAL_URL, list_hidden=False):
 
     for link in soup.find_all('a', href=True, text="files"):
         tmp = link.get("href").split("/")
-        dir_name = tmp[len(tmp)-1]
+        dir_name = tmp[len(tmp) - 1]
         if list_hidden or (dir_name[0] != "."):
             result.append("{}/".format(dir_name))
 


### PR DESCRIPTION
Some queries take long time to get executed. So this feature could be useful to view in logs. 

<img width="645" alt="screen shot 2018-11-07 at 10 15 03 am" src="https://user-images.githubusercontent.com/13504614/48104257-086a4280-e276-11e8-91cd-40a24229c296.png">



<img width="751" alt="screen shot 2018-11-07 at 10 15 36 am" src="https://user-images.githubusercontent.com/13504614/48104272-19b34f00-e276-11e8-8998-ead3b0f937b4.png">
<img width="665" alt="screen shot 2018-11-07 at 10 15 42 am" src="https://user-images.githubusercontent.com/13504614/48104274-1ddf6c80-e276-11e8-8dbe-7409b39efcbb.png">


