### PR TITLE
Separating query contexts and run contexts

### DIFF
--- a/adr/context.py
+++ b/adr/context.py
@@ -1,0 +1,236 @@
+import ast
+import inspect
+from jsone.interpreter import ExpressionEvaluator
+from jsone.prattparser import prefix
+
+COMMON_CONTEXTS = {
+    'branch': [['-B', '--branch'],
+               {'default': 'mozilla-central',
+                'help': "Branches to query results from",
+                }],
+    'build_type': [['-b', '--build-type'],
+                   {'default': 'opt',
+                    'help': "Build type (default: opt)",
+                    }],
+    'from_date': [['--from'],
+                  {'default': 'today-week',
+                   'help': "Starting date to pull data from, defaults "
+                           "to a week ago",
+                   }],
+    'to_date': [['--to'],
+                {'default': 'eod',  # end of day
+                 'help': "Ending date to pull data from, defaults "
+                         "to now",
+                 }],
+    'path': [['--path'],
+             {'required': True,
+              'default': 'dom/indexedDB',
+              'help': "Path relative to repository root (file or directory)",
+              }],
+    'platform': [['-p', '--platform'],
+                 {'default': 'windows10-64',
+                  'help': "Platform to limit results to (default: windows10-64)",
+                  }],
+    'rev': [['-r', '--revision'],
+            {'required': True,
+             'default': '5b33b070378a',
+             'help': "Revision to limit results to",
+             }],
+    'test_name': [['-t', '--test'],
+                  {'required': True,
+                   'help': "Path to a test file",
+                   }],
+    'limit': [['--limit'],
+              {'type': int,
+               'default': 10,
+               'help': "limit the number of rows in result"
+               }],
+    'format': [['--format'],
+               {'type': str,
+                'default': 'table',
+                'help': "format of result"
+                }],
+    'sort_key': [['--sort-key'],
+                 {'type': int,
+                  'default': 4,
+                  'help': "Key to sort on (int, 0-based index)",
+                  }],
+
+}
+"""
+These are commonly used arguments which can be re-used. They are shared to
+provide a consistent CLI across recipes/queries.
+"""
+
+
+class ZeroContextEvaluator(ExpressionEvaluator):
+    """
+    Zero context evaluator is used in conjunction with extract_context_names
+    to extract argument context as a token value
+    """
+
+    def __init__(self):
+        # Init evaluator with fake empty context
+        super(ZeroContextEvaluator, self).__init__({})
+        self.infix_rules = super(ZeroContextEvaluator, self).infix_rules
+        for k, v in super(ZeroContextEvaluator, self).prefix_rules.items():
+            self.prefix_rules.setdefault(k, v)
+        # Init empty context set
+        self.contexts = set()
+
+    @prefix("identifier")
+    def identifier(self, token, pc):
+        """
+        Get corresponding value for token
+        In this function, we return the same token value without using context
+        Args:
+            token: token object
+            pc: parse context
+
+        Returns: same token value
+
+        """
+        self.contexts.add(token.value)
+        return token.value
+
+    def parse(self, expression):
+        """
+        Parse current expression, return contexts inside this expression
+        Args:
+            expression (str): expression
+
+        Returns:
+            set of contexts
+
+        """
+        self.contexts.clear()
+        super(ZeroContextEvaluator, self).parse(expression)
+        return self.contexts
+
+
+G_ZEROCONTEXT_EVALUATOR = ZeroContextEvaluator()
+
+
+def extract_context_names(query):
+    """
+    Extract contexts list from query object
+    This is to mimic json-e render() function
+    Given using only $eval in query
+    Args:
+        query (dict): query object to extract context
+
+    Returns:
+        contexts (set): set of context names
+
+    """
+    contexts = set()
+    if isinstance(query, dict):
+        for k, v in query.items():
+            if k == "$eval":
+                contexts.update(G_ZEROCONTEXT_EVALUATOR.parse(v))
+            else:
+                contexts.update(extract_context_names(v))
+    elif isinstance(query, list):
+        for v in query:
+            contexts.update(extract_context_names(v))
+
+    return contexts
+
+
+def get_context_definitions(definitions):
+    """
+    Build full context definitions from list of contexts with pre-defined definitions
+
+    Args:
+        definitions (list): mixed array of string and context definitions
+
+    Returns:
+        result (dict): a full dictionary of context definitions,
+     each context definition has a name as key and attributes as value
+    """
+
+    result = {}
+
+    for item in definitions:
+        if isinstance(item, dict):
+            result.update(item)
+        elif isinstance(item, str):
+            if item in COMMON_CONTEXTS:
+                result.setdefault(item, COMMON_CONTEXTS[item])
+            else:
+                # Still not found! bad definition
+                raise AttributeError("Cannot find definition for context {}".format(item))
+        else:
+            raise TypeError("Only accept str/list, but found {}".format(type(item)))
+    return result
+
+
+def _extract_func(name, members):
+    """
+    Extract function whose name is `name` from list of members objects
+
+    Args:
+        name (str): func name to extract
+        members (list): list of member object
+
+    Returns: function object
+
+    """
+    for member in members:
+        if member[0] == name:
+            return member[1]
+    return None
+
+
+def extract_arguments(func, call, members=None):
+    """
+    Extract children calls and arguments attributes from a function object
+    Args:
+        func(function object): function object to extract
+        call(str): name of child function being called inside func
+        members(list): extractor function with the found ast.Call,
+                    default to get first string argument
+
+    Returns:
+        calls (set): set of extracted values
+        attrs (set): set of attributes
+
+    """
+    module = inspect.getmodule(func)
+    if not members:
+        members = inspect.getmembers(module, inspect.isfunction)
+    # Get source from function
+    source = inspect.getsource(func)
+    # Get ast tree for this source code
+    root_node = ast.parse(source)
+    if not isinstance(root_node, ast.Module) or not isinstance(root_node.body[0], ast.FunctionDef):
+        raise AttributeError("Expect function definition")
+
+    root_func = root_node.body[0]
+    # Get root args, only support first arg
+    # TODO: support multiple args fetching
+    root_arg = root_func.args.args[0].arg
+    calls = set()
+    attrs = set()
+    # Walk through all descendants recursively
+    for node in ast.walk(root_node):
+        # Check for Call and Attribute
+        # Attribute first
+        if isinstance(node, ast.Attribute):
+            if node.value.id == root_arg:
+                attrs.add(node.attr)
+            continue
+        # Early termination if not Call node with Name function
+        elif not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+            continue
+
+        if node.func.id == call:
+            calls.add(node.args[0].s)
+        else:
+            # Check recursively from member if member is in the same module
+            member = _extract_func(node.func.id, members)
+            if member:
+                _calls, _attrs = extract_arguments(member, call, members)
+                calls.update(_calls)
+                attrs.update(_attrs)
+    return calls, attrs

--- a/adr/recipe.py
+++ b/adr/recipe.py
@@ -3,10 +3,12 @@ from __future__ import print_function, absolute_import
 import importlib
 import logging
 import os
+
+from .query import run_query, load_query_context
 from argparse import ArgumentParser
 from adr.formatter import all_formatters
 from .errors import MissingDataError
-
+from adr import context
 log = logging.getLogger('adr')
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -73,6 +75,34 @@ provide a consistent CLI across recipes.
 """
 
 
+def set_config(config):
+    global G_CONFIG
+    G_CONFIG = config
+
+
+def set_query_context(query_args):
+    global G_CONTEXT
+    G_CONTEXT = vars(query_args)
+
+
+def execute_query(query_name, override_context=None):
+    """
+    Run query
+    Args:
+        query_name (str): name of query
+        override_context (list): updated context from previous query
+    Returns: (str)
+
+    """
+    if not override_context:
+        override_context = G_CONTEXT
+    else:
+        for key, value in G_CONTEXT:
+            if not (key in override_context):
+                override_context[key] = value
+    return next(run_query(query_name, G_CONFIG, **override_context))["data"]
+
+
 class RecipeParser(ArgumentParser):
     arguments = []
 
@@ -89,22 +119,73 @@ class RecipeParser(ArgumentParser):
                 group.add_argument(*cli, **kwargs)
 
 
+class StructureParser(ArgumentParser):
+    def __init__(self, definitions):
+        ArgumentParser.__init__(self)
+        for name, definition in definitions.items():
+            if len(definition) < 2:
+                raise AttributeError("Definition of {} should be list of length 2".format(name))
+            # Set destination from name
+            definition[1]['dest'] = name
+            self.add_argument(*definition[0], **definition[1])
+
+
 def run_recipe(recipe, args, config):
     """Given a recipe, calls the appropriate query and returns the result.
 
     The provided recipe name is used to make a call to the modules.
 
-    :param str recipe: name of the recipe to be run.
-    :param list args: remainder arguments that were unparsed.
-    :param Configuration config: config object.
+    Args:
+        recipe (str): name of the recipe to be run.
+        args (list): remainder arguments that were unparsed.
+        config (Configuration): config object.
+
+    Returns:
+        output (str): output after formatted.
+
+
+    :param str recipe:
+    :param list :
+    :param Configuration config: .
     :returns: string
     """
     modname = '.recipes.{}'.format(recipe)
     mod = importlib.import_module(modname, package='adr')
-    try:
-        output = mod.run(args, config)
-    except MissingDataError:
-        return "ActiveData didn\'t return any data."
+    if recipe == 'config_durations':
+
+        # Get queries and run_contexts by function
+        if (hasattr(mod, 'get_queries')) and (hasattr(mod, 'get_run_args')):
+            queries = mod.get_queries()
+            run_contexts = mod.get_run_args()
+        else:
+            # try to extract automatically from run function
+            queries, run_contexts = context.extract_arguments(mod.run, "execute_query")
+
+        recipe_context_def = {}
+        for query_name in set(queries):
+            query_context_def = load_query_context(query_name)
+            recipe_context_def.update(query_context_def)
+
+        run_context_def = context.get_context_definitions(run_contexts)
+        recipe_context_def.update(run_context_def)
+
+        # get value of query parameters and post-processing parameters
+        parsed_args = StructureParser(recipe_context_def).parse_args(args)
+        set_config(config)
+        # TODO: Split recipe_args into query_args and recipe_args while keep --help works correctly
+
+        recipe_args = parsed_args
+        set_query_context(recipe_args)
+
+        try:
+            output = mod.run(recipe_args)
+        except MissingDataError:
+            return "ActiveData didn\'t return any data."
+    else:
+        try:
+            output = mod.run(args, config)
+        except MissingDataError:
+            return "ActiveData didn\'t return any data."
 
     if isinstance(config.fmt, str):
         fmt = all_formatters[config.fmt]

--- a/adr/recipes/config_durations.py
+++ b/adr/recipes/config_durations.py
@@ -7,22 +7,24 @@ Get the average and total runtime for build platforms and types.
 """
 from __future__ import print_function, absolute_import
 
-from ..recipe import RecipeParser
-from ..query import run_query
+from ..recipe import execute_query
+
+# NO need to define query list, use automatic detection
+# def get_queries():
+#     return ['config_durations']
+
+# NO need to define query list, use automatic detection
+# def get_queries():
+#     return ['config_durations']
+
+# NO need to define run argument definition, use automatic detection
+# def get_run_contexts():
+#     return ["sort_key", "limit"]
 
 
-def run(args, config):
-    parser = RecipeParser('date', 'branch')
-    parser.add_argument('--limit', type=int, default=50,
-                        help="Maximum number of jobs to return")
-    parser.add_argument('--sort-key', type=int, default=4,
-                        help="Key to sort on (int, 0-based index)")
-
-    args = parser.parse_args(args)
-    query_args = vars(args)
-    limit = query_args.pop('limit')
-
-    data = next(run_query('config_durations', config, **query_args))['data']
+def run(args):
+    # process config data
+    data = execute_query('config_durations')
     result = []
     for record in data:
         if isinstance(record[1], list):
@@ -35,6 +37,6 @@ def run(args, config):
         record.append(int(round(record[2] * record[3], 0)))
         result.append(record)
 
-    result = sorted(result, key=lambda k: k[args.sort_key], reverse=True)[:limit]
+    result = sorted(result, key=lambda k: k[args.sort_key], reverse=True)[:args.limit]
     result.insert(0, ['Platform', 'Type', 'Num Jobs', 'Average Hours', 'Total Hours'])
     return result

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -1,0 +1,54 @@
+from adr import context
+import pytest
+
+CONTEXTS = [
+    ({
+        "from": "mozilla"
+    }, []),
+    ({
+        "$eval": "branch"
+    }, ["branch"]),
+    ({
+        "in": {"repo.branch.name": {"$eval": "branch"}}
+    }, ["branch"]),
+    ({
+        "in": {"repo.branch.name": {"$eval": "branch"}},
+        "where": {"condition": {"$eval": "branch + build"}}
+    }, ["branch", "build"]),
+    ({
+        "$eval": "branch + type"
+    }, ["branch", "type"]),
+]
+
+
+@pytest.mark.parametrize("query, expected_contexts", CONTEXTS, ids=str)
+def test_extract_context_names(query, expected_contexts):
+    contexts = context.extract_context_names(query)
+    assert set(expected_contexts) == contexts
+
+
+DEFINITIONS = [
+    (["branch"],
+     {'branch': [['-B', '--branch'],
+                 {'default': 'mozilla-central',
+                  'help': "Branches to query results from",
+                  }]}),
+    (["branch", {'custom': [['-C', '--custom'],
+                            {'default': 'custom value',
+                             'help': "Custom value not in common",
+                             }]}],
+     {'branch': [['-B', '--branch'],
+                 {'default': 'mozilla-central',
+                  'help': "Branches to query results from",
+                  }],
+      'custom': [['-C', '--custom'],
+                 {'default': 'custom value',
+                  'help': "Custom value not in common",
+                  }]})
+]
+
+
+@pytest.mark.parametrize("contexts, expected_definitions", DEFINITIONS, ids=str)
+def test_get_definitions(contexts, expected_definitions):
+    definitions = context.get_context_definitions(contexts)
+    assert expected_definitions == definitions


### PR DESCRIPTION
This PR continues from https://github.com/mozilla/active-data-recipes/pull/78 to solve issue #40 with these changes:
- Change context definition from list to dict
- Add test for context.py
- Update docstring