### PR TITLE
Hide broken recipes and number validation for context input data

### DIFF
--- a/adr/recipe.py
+++ b/adr/recipe.py
@@ -116,3 +116,9 @@ def get_docstring(recipe):
     modname = '.recipes.{}'.format(recipe)
     mod = importlib.import_module(modname, package='adr')
     return publish_parts(mod.__doc__, writer_name='html')['html_body']
+
+
+def is_fail(recipe):
+    modname = '.recipes.{}'.format(recipe)
+    mod = importlib.import_module(modname, package='adr')
+    return hasattr(mod, "is_fail") and mod.is_fail()

--- a/adr/recipe.py
+++ b/adr/recipe.py
@@ -67,6 +67,18 @@ def get_recipe_contexts(recipe, mod=None):
     return recipe_context_def
 
 
+def get_module(name):
+    """
+    Get module of a recipe
+    Args:
+        name (str): name of recipe
+    :return: module
+    """
+    modname = '.recipes.{}'.format(name)
+    mod = importlib.import_module(modname, package='adr')
+    return mod
+
+
 def run_recipe(recipe, args, config, from_cli=True):
     """Given a recipe, calls the appropriate query and returns the result.
 
@@ -82,8 +94,7 @@ def run_recipe(recipe, args, config, from_cli=True):
 
     """
 
-    modname = '.recipes.{}'.format(recipe)
-    mod = importlib.import_module(modname, package='adr')
+    mod = get_module(recipe)
 
     recipe_context_def = get_recipe_contexts(recipe, mod)
 
@@ -113,12 +124,10 @@ def get_docstring(recipe):
     Result:
         html (transformed from rst)
     """
-    modname = '.recipes.{}'.format(recipe)
-    mod = importlib.import_module(modname, package='adr')
+    mod = get_module(recipe)
     return publish_parts(mod.__doc__, writer_name='html')['html_body']
 
 
 def is_fail(recipe):
-    modname = '.recipes.{}'.format(recipe)
-    mod = importlib.import_module(modname, package='adr')
-    return hasattr(mod, "is_fail") and mod.is_fail()
+    mod = get_module(recipe)
+    return getattr(mod, "BROKEN", False)

--- a/adr/recipes/code_coverage.py
+++ b/adr/recipes/code_coverage.py
@@ -10,8 +10,7 @@ from __future__ import print_function, absolute_import
 from ..query import run_query
 
 
-def is_fail():
-    return True
+BROKEN = True
 
 
 def run(config, args):

--- a/adr/recipes/code_coverage.py
+++ b/adr/recipes/code_coverage.py
@@ -10,6 +10,10 @@ from __future__ import print_function, absolute_import
 from ..query import run_query
 
 
+def is_fail():
+    return True
+
+
 def run(config, args):
     """
     THIS IS PRONE TO DOUBLE COUNTING, AS DIFFERENT TEST CHUNKS COVER COMMON LINES

--- a/adr/recipes/intermittent_tests.py
+++ b/adr/recipes/intermittent_tests.py
@@ -10,6 +10,10 @@ from __future__ import print_function, absolute_import
 from ..query import run_query
 
 
+def is_fail():
+    return True
+
+
 def run(config, args):
     # These 4 args are defined so that we can share the queries with the
     # 'intermittent_test_data' recipe.

--- a/adr/recipes/intermittent_tests.py
+++ b/adr/recipes/intermittent_tests.py
@@ -9,9 +9,7 @@ from __future__ import print_function, absolute_import
 
 from ..query import run_query
 
-
-def is_fail():
-    return True
+BROKEN = True
 
 
 def run(config, args):

--- a/adr/recipes/raw_coverage.py
+++ b/adr/recipes/raw_coverage.py
@@ -18,6 +18,7 @@ from ..query import run_query
 
 OUTPUTFILE_PREFIX = 'coverage_map'
 log = logging.getLogger('adr')
+BROKEN = True
 
 
 def removeJob(lines, jobname):
@@ -39,10 +40,6 @@ def taskclusterName(jobname):
     # output data to .json file, create format like: test-linux64/debug-<jobname>
     # todo, there are a lot of exceptions.
     return "test-linux64/debug-%s" % jobname
-
-
-def is_fail():
-    return True
 
 
 def run(config, args):

--- a/adr/recipes/raw_coverage.py
+++ b/adr/recipes/raw_coverage.py
@@ -41,6 +41,10 @@ def taskclusterName(jobname):
     return "test-linux64/debug-%s" % jobname
 
 
+def is_fail():
+    return True
+
+
 def run(config, args):
     parser = RecipeParser('path', 'rev')
     parser.add_argument('--use-chunks', default=False, action="store_true",

--- a/adr/recipes/tests_config_times.py
+++ b/adr/recipes/tests_config_times.py
@@ -10,6 +10,10 @@ from __future__ import print_function, absolute_import
 from ..query import run_query
 
 
+def is_fail():
+    return True
+
+
 def run(config, args):
 
     result = run_query('tests_config_times', config, args)['data']

--- a/adr/recipes/tests_config_times.py
+++ b/adr/recipes/tests_config_times.py
@@ -9,9 +9,7 @@ from __future__ import print_function, absolute_import
 
 from ..query import run_query
 
-
-def is_fail():
-    return True
+BROKEN = True
 
 
 def run(config, args):

--- a/adr/recipes/try_users.py
+++ b/adr/recipes/try_users.py
@@ -29,8 +29,7 @@ RUN_CONTEXTS = ['from_date', 'to_date',
                 ]
 
 
-def is_fail():
-    return True
+BROKEN = True
 
 
 def run(config, args):

--- a/adr/recipes/try_users.py
+++ b/adr/recipes/try_users.py
@@ -29,6 +29,10 @@ RUN_CONTEXTS = ['from_date', 'to_date',
                 ]
 
 
+def is_fail():
+    return True
+
+
 def run(config, args):
 
     header = ['User', 'Tasks', 'Pushes', 'Tasks / Push']

--- a/app/app.py
+++ b/app/app.py
@@ -18,7 +18,9 @@ def get_recipes():
     """
     for file in os.listdir(recipe_path):
         if file.endswith('.py') and file != '__init__.py':
-            recipe_lists.append(file.rsplit('.', 1)[0])
+            recipe_name = file.rsplit('.', 1)[0]
+            if not recipe.is_fail(recipe_name):
+                recipe_lists.append(recipe_name)
 
     recipe_lists.sort()
 
@@ -61,6 +63,11 @@ def recipe_handler(recipe_name):
         for k, v in recipe_contexts.items():
             if k in request.args:
                 v[1]['default'] = request.args[k]
+    else:
+        # Transform type into string
+        for k, v in recipe_contexts.items():
+            if 'type' in v[1]:
+                v[1]['type'] = v[1]['type'].__name__
 
     return render_template('recipe.html', recipes=recipe_lists, recipe=recipe_name,
                            recipe_contexts=recipe_contexts,

--- a/app/templates/recipe.html
+++ b/app/templates/recipe.html
@@ -21,13 +21,18 @@
     <form id="recipe_input" recipe="{{recipe}}" method="GET">
         {% for key, value in recipe_contexts.items() %}
                 <div class="field">
-                    <label class="label">{{key}}</label>
+                    <label class="label">{{key}} </label>
                     <p class="help">{{value[1].help}}</p>
                     <div id="recipe_contexts" class="control">
-                        <input class="input" id={{key}} name={{key}} type="text" placeholder="Text input"
-                               {% if ("default" in value[1]) and (value[1].default != None) %}
-                                   value={{value[1].default}}
-                               {% endif %}  >
+                        <input class="input" id={{key}} name={{key}} placeholder="Text input"
+                            {% if ("type" in value[1]) and (value[1].type == 'int') %}
+                               type="number"
+                            {% else %} type="text"
+                            {% endif %}
+
+                            {% if ("default" in value[1]) and (value[1].default != None) %}
+                               value={{value[1].default}}
+                            {% endif %}  />
                     </div>
                 </div>
         {% endfor %}

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=py36,flake8,doclint
 [testenv]
 deps=
     pytest >= 3.0.0, <4
+    docutils
 passenv=TRAVIS_EVENT_TYPE
 commands=pytest -vv -rfx --tb=short
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ commands=pytest -vv -rfx --tb=short
 [testenv:integration]
 deps=
     pytest >= 3.0.0, <4
+    docutils
 setenv=
     TRAVIS_EVENT_TYPE=cron
 commands=pytest -vv -rfx --tb=short test/test_recipes_integration.py


### PR DESCRIPTION
- Hide broken recipes: if a recipe is failed, it should be marked inside that recipe through `is_fail` function. Web-app will not show these recipes on recipe list (left menu). The integration test was updated also.
- Number validation for context input data: if "type" of this context is int, user will be required to put number on the input textbox