### PR TITLE
Output file

### DIFF
--- a/adr/cli.py
+++ b/adr/cli.py
@@ -19,11 +19,10 @@ log.setLevel(logging.DEBUG)
 log.addHandler(logging.StreamHandler())
 
 
-def print_to_file(data):
-    filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'results.json')
+def print_to_file(data, filename):
+    filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), filename)
     f = open(filepath, "x")
-    for i in data:
-        f.write("This is line {}\n".format(i))
+    f.write(data)
     f.close()
 
 
@@ -35,7 +34,7 @@ def format_request(request, config, remainder, request_type):
         data = run_recipe(request, remainder, config)
         url = None
     if config.output_file:
-        print_to_file(data)
+        print_to_file(data, config.output_file)
     return data, url
 
 
@@ -103,15 +102,13 @@ def _build_parser_arguments(parser, config):
                         help="Endpoint URL")
     parser.add_argument('-d', '--debug', action='store_true', default=config.debug,
                         help="Open a query in ActiveData query tool.")
-    parser.add_argument('-of', '--output-file', action='store_true', default=config.output_file,
-                        help="Send the result to file instead of stdout.")
     # positional arguments
     parser.add_argument('task', nargs='*')
     parser.add_argument(
-        '-h',
-        '--help',
-        action='store_true',
+        '-h', '--help', action='store_true',
         help="Type --help to get help.\nType <recipe> --help to get help with a recipe.")
+    parser.add_argument('-of', '--output-file', type=str,
+                        help="Name of output file")
     return parser
 
 

--- a/adr/cli.py
+++ b/adr/cli.py
@@ -19,8 +19,7 @@ log.setLevel(logging.DEBUG)
 log.addHandler(logging.StreamHandler())
 
 
-def print_to_file(data, filename):
-    filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), filename)
+def print_to_file(data, filepath):
     f = open(filepath, "x")
     f.write(data)
     f.close()
@@ -108,7 +107,7 @@ def _build_parser_arguments(parser, config):
         '-h', '--help', action='store_true',
         help="Type --help to get help.\nType <recipe> --help to get help with a recipe.")
     parser.add_argument('-of', '--output-file', type=str,
-                        help="Name of output file")
+                        help="Full path of the output file")
     return parser
 
 

--- a/adr/cli.py
+++ b/adr/cli.py
@@ -19,12 +19,6 @@ log.setLevel(logging.DEBUG)
 log.addHandler(logging.StreamHandler())
 
 
-def print_to_file(data, filepath):
-    f = open(filepath, "x")
-    f.write(data)
-    f.close()
-
-
 def format_request(request, config, remainder, request_type):
 
     if request_type == "query":
@@ -33,7 +27,7 @@ def format_request(request, config, remainder, request_type):
         data = run_recipe(request, remainder, config)
         url = None
     if config.output_file:
-        print_to_file(data, config.output_file)
+        print(data, file=open(config.output_file, 'w'))
     return data, url
 
 
@@ -106,7 +100,7 @@ def _build_parser_arguments(parser, config):
     parser.add_argument(
         '-h', '--help', action='store_true',
         help="Type --help to get help.\nType <recipe> --help to get help with a recipe.")
-    parser.add_argument('-of', '--output-file', type=str,
+    parser.add_argument('-o', '--output-file', type=str,
                         help="Full path of the output file")
     return parser
 

--- a/adr/cli.py
+++ b/adr/cli.py
@@ -19,6 +19,14 @@ log.setLevel(logging.DEBUG)
 log.addHandler(logging.StreamHandler())
 
 
+def print_to_file(data):
+    filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'results.json')
+    f = open(filepath, "x")
+    for i in data:
+        f.write("This is line {}\n".format(i))
+    f.close()
+
+
 def format_request(request, config, remainder, request_type):
 
     if request_type == "query":
@@ -26,6 +34,8 @@ def format_request(request, config, remainder, request_type):
     else:
         data = run_recipe(request, remainder, config)
         url = None
+    if config.output_file:
+        print_to_file(data)
     return data, url
 
 
@@ -93,6 +103,8 @@ def _build_parser_arguments(parser, config):
                         help="Endpoint URL")
     parser.add_argument('-d', '--debug', action='store_true', default=config.debug,
                         help="Open a query in ActiveData query tool.")
+    parser.add_argument('-of', '--output-file', action='store_true', default=config.output_file,
+                        help="Send the result to file instead of stdout.")
     # positional arguments
     parser.add_argument('task', nargs='*')
     parser.add_argument(

--- a/adr/config.yml
+++ b/adr/config.yml
@@ -3,3 +3,4 @@ debug_url: https://activedata.allizom.org/tools/query.html#query_id={}
 verbose: false
 debug: false
 fmt: table
+output_file: false

--- a/adr/config.yml
+++ b/adr/config.yml
@@ -3,4 +3,4 @@ debug_url: https://activedata.allizom.org/tools/query.html#query_id={}
 verbose: false
 debug: false
 fmt: table
-output_file: false
+output_file: none

--- a/adr/util/config.py
+++ b/adr/util/config.py
@@ -7,7 +7,8 @@ class Configuration(object):
         "verbose",
         "debug",
         "debug_url",
-        "fmt"
+        "fmt",
+        "output_file"
     ]
 
     def __init__(self, yml_file=None):


### PR DESCRIPTION
Add --output-file <fullpath of file> so that the result will be send to a file (only the result goes to the file, other information such as verbose log statements don't).